### PR TITLE
Use non-deprecated bound_iam_role_arns for vault_aws_auth_backend_role

### DIFF
--- a/modules/aws-auth/main.tf
+++ b/modules/aws-auth/main.tf
@@ -7,39 +7,39 @@ resource "vault_auth_backend" "aws" {
 }
 
 resource "vault_aws_auth_backend_role" "consul" {
-  backend            = "${vault_auth_backend.aws.path}"
-  role               = "${var.consul_role}"
-  auth_type          = "ec2"
-  bound_iam_role_arn = "${var.consul_iam_role_arn}"
-  policies           = ["${sort(concat(var.base_policies, var.consul_policies))}"]
-  period             = "${var.period_minutes}"
+  backend             = "${vault_auth_backend.aws.path}"
+  role                = "${var.consul_role}"
+  auth_type           = "ec2"
+  bound_iam_role_arns = ["${var.consul_iam_role_arn}"]
+  policies            = ["${sort(concat(var.base_policies, var.consul_policies))}"]
+  period              = "${var.period_minutes}"
 }
 
 resource "vault_aws_auth_backend_role" "nomad_server" {
-  backend            = "${vault_auth_backend.aws.path}"
-  role               = "${var.nomad_server_role}"
-  auth_type          = "ec2"
-  bound_iam_role_arn = "${var.nomad_server_iam_role_arn}"
-  policies           = ["${sort(concat(var.base_policies, var.nomad_server_policies))}"]
-  period             = "${var.period_minutes}"
+  backend             = "${vault_auth_backend.aws.path}"
+  role                = "${var.nomad_server_role}"
+  auth_type           = "ec2"
+  bound_iam_role_arns = ["${var.nomad_server_iam_role_arn}"]
+  policies            = ["${sort(concat(var.base_policies, var.nomad_server_policies))}"]
+  period              = "${var.period_minutes}"
 }
 
 resource "vault_aws_auth_backend_role" "nomad_client" {
-  backend            = "${vault_auth_backend.aws.path}"
-  role               = "${var.nomad_client_role}"
-  auth_type          = "ec2"
-  bound_iam_role_arn = "${var.nomad_client_iam_role_arn}"
-  policies           = ["${sort(concat(var.base_policies, var.nomad_client_policies))}"]
-  period             = "${var.period_minutes}"
+  backend             = "${vault_auth_backend.aws.path}"
+  role                = "${var.nomad_client_role}"
+  auth_type           = "ec2"
+  bound_iam_role_arns = ["${var.nomad_client_iam_role_arn}"]
+  policies            = ["${sort(concat(var.base_policies, var.nomad_client_policies))}"]
+  period              = "${var.period_minutes}"
 }
 
 resource "vault_aws_auth_backend_role" "vault" {
-  backend            = "${vault_auth_backend.aws.path}"
-  role               = "${var.vault_role}"
-  auth_type          = "ec2"
-  bound_iam_role_arn = "${var.vault_iam_role_arn}"
-  policies           = ["${sort(concat(var.base_policies, var.vault_policies))}"]
-  period             = "${var.period_minutes}"
+  backend             = "${vault_auth_backend.aws.path}"
+  role                = "${var.vault_role}"
+  auth_type           = "ec2"
+  bound_iam_role_arns = ["${var.vault_iam_role_arn}"]
+  policies            = ["${sort(concat(var.base_policies, var.vault_policies))}"]
+  period              = "${var.period_minutes}"
 }
 
 ################################################


### PR DESCRIPTION
Ref: https://www.terraform.io/docs/providers/vault/r/aws_auth_backend_role.html#bound_iam_role_arns