### PR TITLE
Explicitly set generate_signing_key to true to prevent breaking changes

### DIFF
--- a/modules/vault-ssh/ssh-engine/main.tf
+++ b/modules/vault-ssh/ssh-engine/main.tf
@@ -7,8 +7,10 @@ resource "vault_mount" "ssh" {
 }
 
 resource "vault_ssh_secret_backend_ca" "ssh" {
-  count   = "${var.enabled ? 1 : 0}"
-  backend = "${vault_mount.ssh.path}"
+  count = "${var.enabled ? 1 : 0}"
+
+  backend              = "${vault_mount.ssh.path}"
+  generate_signing_key = true
 }
 
 data "template_file" "role" {


### PR DESCRIPTION
The documentation was lying I think (or not up to date?):
https://www.terraform.io/docs/providers/vault/r/ssh_secret_backend_ca.html#generate_signing_key

`Default` was not set for `generate_signing_key` (at latest Vault provider v1.7.0):
https://github.com/terraform-providers/terraform-provider-vault/blob/04893e7b185b5e534ac1c6525a3abf9569f2f9a7/vault/resource_ssh_secret_backend_ca.go#L33

Previously kept getting:
```bash
* missing public_key
* xxx.module.vault.vault_ssh_secret_backend_ca.ssh: 1 error(s) occurred:

* vault_ssh_secret_backend_ca.ssh: Error writing CA information for backend "xxx": Error making API request.
```
because `generate_signing_key` defaults to `false`, which would require both public and private keys to be set.