### PR TITLE
Dynamically find absolute python3 path

### DIFF
--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -85,7 +85,7 @@ as part of _all_ your Packer AMI building. -->
 ## Building AMIs
 
 We first need to use [packer](https://www.packer.io/) to build several AMIs. You will also need to
-have Ansible 2.6 installed.
+have Ansible 2.7 installed.
 
 The list below will link to example packer scripts that we have provided. If you have additional
 requirements, you are encouraged to extend from these examples.

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -22,7 +22,7 @@ configuration. They are documented briefly below, and in more detail in their ow
 ## Requirements
 
 - AWS account with an access key and secret for programmatic access
-- [Ansible >= 2.6](https://github.com/ansible/ansible/releases)
+- [Ansible >= 2.7](https://github.com/ansible/ansible/releases)
 - [AWS CLI](https://aws.amazon.com/cli/)
 - [terraform](https://www.terraform.io/)
 - [nomad](https://www.nomadproject.io/)

--- a/modules/core/packer/consul/packer.json
+++ b/modules/core/packer/consul/packer.json
@@ -96,7 +96,7 @@
                 "-e",
                 "timezone={{user `timezone`}}",
                 "-e",
-                "ansible_python_interpreter=/usr/bin/python3"
+                "ansible_python_interpreter=\"$(command -v python3)\""
             ]
         }
     ]

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -118,7 +118,7 @@
                 "-e",
                 "timezone={{user `timezone`}}",
                 "-e",
-                "ansible_python_interpreter=/usr/bin/python3",
+                "ansible_python_interpreter=\"$(command -v python3)\"",
                 "-e",
                 "{{user `extra_vars`}}"
             ]

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -110,7 +110,7 @@
                 "-e",
                 "timezone={{user `timezone`}}",
                 "-e",
-                "ansible_python_interpreter=/usr/bin/python3",
+                "ansible_python_interpreter=\"$(command -v python3)\"",
                 "-e",
                 "{{user `extra_vars`}}"
             ]

--- a/modules/core/packer/vault/packer.json
+++ b/modules/core/packer/vault/packer.json
@@ -108,7 +108,7 @@
                 "-e",
                 "timezone={{user `timezone`}}",
                 "-e",
-                "ansible_python_interpreter=/usr/bin/python3"
+                "ansible_python_interpreter=\"$(command -v python3)\""
             ]
         }
     ]


### PR DESCRIPTION
Currently, the absolute python3 path defined in the packer
config file only work for some unix and linux OS. This change
shall ask the respective OS to print their own absolute python3
path, so that it also works with Mac OS without having to
circumvent integrity protection to link python3 from
/usr/local/bin/python3 to /usr/bin/python3