### PR TITLE
Add EFS module

### DIFF
--- a/modules/efs/README.md
+++ b/modules/efs/README.md
@@ -45,6 +45,7 @@ job "xxx" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| allowed\_cidr\_blocks | CIDR blocks to allow EFS port access into the security group | list | n/a | yes |
 | efs\_ports | Ports to allow access to EFS | map | `<map>` | no |
 | kms\_additional\_tags | KMS key additional tags for EFS | map | `<map>` | no |
 | kms\_key\_alias | Alias for the KMS key for EFS. Must prefix with alias/. Overrides kms_key_alias_prefix if this is specified. | string | `""` | no |

--- a/modules/efs/README.md
+++ b/modules/efs/README.md
@@ -3,6 +3,8 @@
 This module creates AWS EFS to be available for services that require persistent
 storage.
 
+Currently this assumes that the EFS is always custom KMS encrypted.
+
 ## Nomad job instruction on mounting
 
 To mount EFS into one of the Nomad job running Docker, the Nomad jobspec should
@@ -50,13 +52,21 @@ job "xxx" {
 | security\_group\_name | Name of security group for EFS. Empty string to use a random name. | string | `""` | no |
 | tags | Tags to apply to resources that allow it | map | `<map>` | no |
 | vpc\_id | ID of VPC to add the security group for the EFS setup | string | n/a | yes |
-| vpc\_subnets | IDs of VPC subnets to add the mount targets in | string | n/a | yes |
+| vpc\_subnets | IDs of VPC subnets to add the mount targets in | list | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| arn | ARN of EFS |
 | dns\_name | DNS name of EFS |
-| id | ID of the setup EFS |
-| kms\_key\_alias | KMS key alias used for encryption |
+| id | ID of EFS |
+| kms\_key\_alias | KMS key alias used for EFS encryption |
+| kms\_key\_arn | ARN of KMS key used for EFS encryption |
+| kms\_key\_key\_id | Key ID of KMS key used for EFS encryption |
+| mount\_target\_dns\_names | Mount target DNS names of EFS. The order of elements is the same as the order of the given vpc_subnets. |
+| mount\_target\_ids | Mount target IDs of EFS. The order of elements is the same as the order of the given vpc_subnets. |
 | root\_resource | ARN of EFS resource at root |
+| security\_group\_arn | ARN of the EFS security group |
+| security\_group\_id | ID of the EFS security group |
+| security\_group\_name | Name of the EFS security group |

--- a/modules/efs/README.md
+++ b/modules/efs/README.md
@@ -1,0 +1,62 @@
+# AWS EFS
+
+This module creates AWS EFS to be available for services that require persistent
+storage.
+
+## Nomad job instruction on mounting
+
+To mount EFS into one of the Nomad job running Docker, the Nomad jobspec should
+look something like the following:
+
+```hcl
+job "xxx" {
+  group "xxx" {
+    task "xxx" {
+      config {
+        image = "xxx"
+
+        mounts = [
+          {
+            source   = "${efs_id}/"
+            target   = "/mnt/whatever/dir/name/you/want"
+            readonly = false
+
+            volume_options {
+              driver_config {
+                name = "efs"
+              }
+            }
+          },
+        ]
+
+        # Required for mount --bind
+        privileged = true
+
+        ...
+      }
+    }
+  }
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| efs\_ports | Ports to allow access to EFS | map | `<map>` | no |
+| kms\_additional\_tags | KMS key additional tags for EFS | map | `<map>` | no |
+| kms\_key\_alias | Alias for the KMS key for EFS. Must prefix with alias/. Overrides kms_key_alias_prefix if this is specified. | string | `""` | no |
+| kms\_key\_alias\_prefix | Alias prefix for the KMS key for EFS. Current timestamp is used as the suffix. Must prefix with alias/. kms_key_alias is used instead if specified. | string | `"alias/efs-default-"` | no |
+| security\_group\_name | Name of security group for EFS. Empty string to use a random name. | string | `""` | no |
+| tags | Tags to apply to resources that allow it | map | `<map>` | no |
+| vpc\_id | ID of VPC to add the security group for the EFS setup | string | n/a | yes |
+| vpc\_subnets | IDs of VPC subnets to add the mount targets in | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| dns\_name | DNS name of EFS |
+| id | ID of the setup EFS |
+| kms\_key\_alias | KMS key alias used for encryption |
+| root\_resource | ARN of EFS resource at root |

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -73,6 +73,6 @@ locals {
   # timestamp() returns 2018-01-02T23:12:01Z, and colon is not allowed for KMS key alias
   formatted_timestamp = "${replace(timestamp(), ":", "-")}"
 
-  kms_key_alias       = "${var.kms_key_alias != "" ? var.kms_key_alias : format("%s%s", var.kms_key_alias_prefix, local.formatted_timestamp)}"
-  kms_key_policy_json = "${var.kms_key_policy_json != "" ? var.kms_key_policy_json : data.aws_iam_policy_document.default.json}"
+  kms_key_alias       = "${coalesce(var.kms_key_alias, format("%s%s", var.kms_key_alias_prefix, local.formatted_timestamp))}"
+  kms_key_policy_json = "${coalesce(var.kms_key_policy_json, data.aws_iam_policy_document.default.json)}"
 }

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -56,5 +56,9 @@ resource "aws_security_group_rule" "efs" {
 locals {
   efs_filesystem_root_resource = "arn:aws:elasticfilesystem:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system"
 
-  kms_key_alias = "${var.kms_key_alias != "" ? var.kms_key_alias : format("%s%s", var.kms_key_alias_prefix, timestamp())}"
+  # timestamp() returns 2018-01-02T23:12:01Z, and colon is not allowed for KMS key alias
+  formatted_timestamp = "${replace(timestamp(), ":", "-")}"
+
+  # 2018-01-02T23:12:01Z
+  kms_key_alias = "${var.kms_key_alias != "" ? var.kms_key_alias : format("%s%s", var.kms_key_alias_prefix, local.formatted_timestamp)}"
 }

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 data "aws_vpc" "efs" {
   id = "${var.vpc_id}"
 }
@@ -56,7 +58,7 @@ resource "aws_security_group_rule" "efs" {
 }
 
 locals {
-  efs_filesystem_root_resource = "arn:aws:elasticfilesystem:${var.aws_region}:${data.aws_caller_identity.current.account_id}:file-system"
+  efs_filesystem_root_resource = "arn:aws:elasticfilesystem:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system"
 
   kms_key_alias = "${var.kms_key_alias != "" ? var.kms_key_alias : format("%s%s", var.kms_key_alias_prefix, timestamp())}"
 }

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -1,0 +1,62 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "efs" {
+  id = "${var.vpc_id}"
+}
+
+resource "aws_kms_key" "encryption" {
+  description         = "Encryption key for EFS"
+  enable_key_rotation = true
+  tags                = "${merge(var.kms_additional_tags, var.tags)}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_kms_alias" "encryption" {
+  name          = "${local.kms_key_alias}"
+  target_key_id = "${aws_kms_key.encryption.key_id}"
+}
+
+resource "aws_efs_file_system" "default" {
+  encrypted  = true
+  kms_key_id = "${aws_kms_key.encryption.arn}"
+  tags       = "${var.tags}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_efs_mount_target" "mounts" {
+  count           = "${length(var.vpc_subnets)}"
+  file_system_id  = "${aws_efs_file_system.default.id}"
+  subnet_id       = "${var.vpc_subnets[count.index]}"
+  security_groups = ["${aws_security_group.efs.id}"]
+}
+
+resource "aws_security_group" "efs" {
+  name        = "${var.security_group_name}"
+  description = "Security group for EFS"
+  vpc_id      = "${var.vpc_id}"
+
+  tags = "${var.tags}"
+}
+
+resource "aws_security_group_rule" "efs" {
+  type = "ingress"
+
+  security_group_id = "${aws_security_group.efs.id}"
+  from_port         = "${var.efs_ports["from"]}"
+  to_port           = "${var.efs_ports["to"]}"
+  protocol          = "${var.efs_ports["protocol"]}"
+
+  cidr_blocks = ["${data.aws_vpc.efs.cidr_block}"]
+}
+
+locals {
+  efs_filesystem_root_resource = "arn:aws:elasticfilesystem:${var.aws_region}:${data.aws_caller_identity.current.account_id}:file-system"
+
+  kms_key_alias = "${var.kms_key_alias != "" ? var.kms_key_alias : format("%s%s", var.kms_key_alias_prefix, timestamp())}"
+}

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -73,7 +73,6 @@ locals {
   # timestamp() returns 2018-01-02T23:12:01Z, and colon is not allowed for KMS key alias
   formatted_timestamp = "${replace(timestamp(), ":", "-")}"
 
-  # 2018-01-02T23:12:01Z
   kms_key_alias       = "${var.kms_key_alias != "" ? var.kms_key_alias : format("%s%s", var.kms_key_alias_prefix, local.formatted_timestamp)}"
   kms_key_policy_json = "${var.kms_key_policy_json != "" ? var.kms_key_policy_json : data.aws_iam_policy_document.default.json}"
 }

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -2,10 +2,6 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
-data "aws_vpc" "efs" {
-  id = "${var.vpc_id}"
-}
-
 resource "aws_kms_key" "encryption" {
   description         = "Encryption key for EFS"
   enable_key_rotation = true
@@ -54,7 +50,7 @@ resource "aws_security_group_rule" "efs" {
   to_port           = "${var.efs_ports["to"]}"
   protocol          = "${var.efs_ports["protocol"]}"
 
-  cidr_blocks = ["${data.aws_vpc.efs.cidr_block}"]
+  cidr_blocks = ["${var.allowed_cidr_blocks}"]
 }
 
 locals {

--- a/modules/efs/outputs.tf
+++ b/modules/efs/outputs.tf
@@ -1,11 +1,41 @@
 output "id" {
-  description = "ID of the setup EFS"
+  description = "ID of EFS"
   value       = "${aws_efs_file_system.default.id}"
+}
+
+output "arn" {
+  description = "ARN of EFS"
+  value       = "${aws_efs_file_system.default.arn}"
 }
 
 output "dns_name" {
   description = "DNS name of EFS"
   value       = "${aws_efs_file_system.default.dns_name}"
+}
+
+output "mount_target_ids" {
+  description = "Mount target IDs of EFS. The order of elements is the same as the order of the given vpc_subnets."
+  value       = "${aws_efs_mount_target.mounts.*.id}"
+}
+
+output "mount_target_dns_names" {
+  description = "Mount target DNS names of EFS. The order of elements is the same as the order of the given vpc_subnets."
+  value       = "${aws_efs_mount_target.mounts.*.dns_name}"
+}
+
+output "security_group_name" {
+  description = "Name of the EFS security group"
+  value       = "${aws_security_group.efs.name}"
+}
+
+output "security_group_arn" {
+  description = "ARN of the EFS security group"
+  value       = "${aws_security_group.efs.arn}"
+}
+
+output "security_group_id" {
+  description = "ID of the EFS security group"
+  value       = "${aws_security_group.efs.id}"
 }
 
 output "root_resource" {
@@ -14,6 +44,16 @@ output "root_resource" {
 }
 
 output "kms_key_alias" {
-  description = "KMS key alias used for encryption"
+  description = "KMS key alias used for EFS encryption"
   value       = "${local.kms_key_alias}"
+}
+
+output "kms_key_arn" {
+  description = "ARN of KMS key used for EFS encryption"
+  value       = "${aws_kms_key.encryption.arn}"
+}
+
+output "kms_key_key_id" {
+  description = "Key ID of KMS key used for EFS encryption"
+  value       = "${aws_kms_key.encryption.key_id}"
 }

--- a/modules/efs/outputs.tf
+++ b/modules/efs/outputs.tf
@@ -1,0 +1,19 @@
+output "id" {
+  description = "ID of the setup EFS"
+  value       = "${aws_efs_file_system.default.id}"
+}
+
+output "dns_name" {
+  description = "DNS name of EFS"
+  value       = "${aws_efs_file_system.default.dns_name}"
+}
+
+output "root_resource" {
+  description = "ARN of EFS resource at root"
+  value       = "${local.efs_filesystem_root_resource}"
+}
+
+output "kms_key_alias" {
+  description = "KMS key alias used for encryption"
+  value       = "${local.kms_key_alias}"
+}

--- a/modules/efs/variables.tf
+++ b/modules/efs/variables.tf
@@ -49,6 +49,25 @@ EOF
   default = ""
 }
 
+variable "kms_key_deletion_window_in_days" {
+  description = <<EOF
+Duration in days after which the key is deleted after destruction of the resource,
+must be between 7 and 30 days
+EOF
+
+  default = 30
+}
+
+variable "kms_key_enable_rotation" {
+  description = "Specifies whether key rotation is enabled"
+  default     = true
+}
+
+variable "kms_key_policy_json" {
+  description = "JSON content of IAM policy to attach to the KMS key. Empty string to use root identifier as principal for all KMS actions."
+  default     = ""
+}
+
 variable "efs_ports" {
   description = "Ports to allow access to EFS"
 

--- a/modules/efs/variables.tf
+++ b/modules/efs/variables.tf
@@ -8,6 +8,7 @@ variable "vpc_id" {
 
 variable "vpc_subnets" {
   description = "IDs of VPC subnets to add the mount targets in"
+  type        = "list"
 }
 
 #
@@ -26,7 +27,7 @@ Must prefix with alias/.
 kms_key_alias is used instead if specified.
 EOF
 
-  default     = "alias/efs-default-"
+  default = "alias/efs-default-"
 }
 
 variable "kms_key_alias" {
@@ -35,7 +36,7 @@ Alias for the KMS key for EFS. Must prefix with alias/.
 Overrides kms_key_alias_prefix if this is specified.
 EOF
 
-  default     = ""
+  default = ""
 }
 
 variable "efs_ports" {

--- a/modules/efs/variables.tf
+++ b/modules/efs/variables.tf
@@ -1,0 +1,66 @@
+#
+# VPC related
+#
+
+variable "vpc_id" {
+  description = "ID of VPC to add the security group for the EFS setup"
+}
+
+variable "vpc_subnets" {
+  description = "IDs of VPC subnets to add the mount targets in"
+}
+
+#
+# EFS related
+#
+
+variable "kms_additional_tags" {
+  description = "KMS key additional tags for EFS"
+  default     = {}
+}
+
+variable "kms_key_alias_prefix" {
+  description = <<EOF
+Alias prefix for the KMS key for EFS. Current timestamp is used as the suffix.
+Must prefix with alias/.
+kms_key_alias is used instead if specified.
+EOF
+
+  default     = "alias/efs-default-"
+}
+
+variable "kms_key_alias" {
+  description = <<EOF
+Alias for the KMS key for EFS. Must prefix with alias/.
+Overrides kms_key_alias_prefix if this is specified.
+EOF
+
+  default     = ""
+}
+
+variable "efs_ports" {
+  description = "Ports to allow access to EFS"
+
+  default = {
+    from     = 2049
+    to       = 2049
+    protocol = "tcp"
+  }
+}
+
+variable "security_group_name" {
+  description = "Name of security group for EFS. Empty string to use a random name."
+  default     = ""
+}
+
+#
+# Others
+#
+
+variable "tags" {
+  description = "Tags to apply to resources that allow it"
+
+  default {
+    Terraform = "true"
+  }
+}

--- a/modules/efs/variables.tf
+++ b/modules/efs/variables.tf
@@ -1,5 +1,5 @@
 #
-# VPC related
+# Security and VPC related
 #
 
 variable "vpc_id" {
@@ -9,6 +9,16 @@ variable "vpc_id" {
 variable "vpc_subnets" {
   description = "IDs of VPC subnets to add the mount targets in"
   type        = "list"
+}
+
+variable "allowed_cidr_blocks" {
+  description = "CIDR blocks to allow EFS port access into the security group"
+  type        = "list"
+}
+
+variable "security_group_name" {
+  description = "Name of security group for EFS. Empty string to use a random name."
+  default     = ""
 }
 
 #
@@ -47,11 +57,6 @@ variable "efs_ports" {
     to       = 2049
     protocol = "tcp"
   }
-}
-
-variable "security_group_name" {
-  description = "Name of security group for EFS. Empty string to use a random name."
-  default     = ""
 }
 
 #


### PR DESCRIPTION
Add a straightforward but opinionated EFS module:
- Adds EFS filesystem
- Adds KMS key + alias for filesystem encryption
- Adds security group to allow given CIDR blocks to access (e.g. Core's CIDR)