### PR TITLE
EFS descriptions and encryption cleanup

### DIFF
--- a/modules/efs/README.md
+++ b/modules/efs/README.md
@@ -3,7 +3,8 @@
 This module creates AWS EFS to be available for services that require persistent
 storage.
 
-Currently this assumes that the EFS is always custom KMS encrypted.
+When encryption is enabled for EFS (which is the default), this module will
+generate a new custom KMS key for this purpose.
 
 ## Nomad job instruction on mounting
 
@@ -47,9 +48,15 @@ job "xxx" {
 |------|-------------|:----:|:-----:|:-----:|
 | allowed\_cidr\_blocks | CIDR blocks to allow EFS port access into the security group | list | n/a | yes |
 | efs\_ports | Ports to allow access to EFS | map | `<map>` | no |
+| enable\_encryption | Boolean to specify whether to enable KMS encryption for EFS | string | `"true"` | no |
 | kms\_additional\_tags | KMS key additional tags for EFS | map | `<map>` | no |
 | kms\_key\_alias | Alias for the KMS key for EFS. Must prefix with alias/. Overrides kms_key_alias_prefix if this is specified. | string | `""` | no |
 | kms\_key\_alias\_prefix | Alias prefix for the KMS key for EFS. Current timestamp is used as the suffix. Must prefix with alias/. kms_key_alias is used instead if specified. | string | `"alias/efs-default-"` | no |
+| kms\_key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days | string | `"30"` | no |
+| kms\_key\_description | Description to use for KMS key | string | `"Encryption key for EFS"` | no |
+| kms\_key\_enable\_rotation | Specifies whether key rotation is enabled | string | `"true"` | no |
+| kms\_key\_policy\_json | JSON content of IAM policy to attach to the KMS key. Empty string to use root identifier as principal for all KMS actions. | string | `""` | no |
+| security\_group\_description | Description of security group for EFS | string | `"Security group for EFS"` | no |
 | security\_group\_name | Name of security group for EFS. Empty string to use a random name. | string | `""` | no |
 | tags | Tags to apply to resources that allow it | map | `<map>` | no |
 | vpc\_id | ID of VPC to add the security group for the EFS setup | string | n/a | yes |

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_kms_key" "encryption" {
-  description             = "Encryption key for EFS"
+  description             = "${var.kms_key_description}"
   deletion_window_in_days = "${var.kms_key_deletion_window_in_days}"
   enable_key_rotation     = "${var.kms_key_enable_rotation}"
   policy                  = "${local.kms_key_policy_json}"
@@ -50,7 +50,7 @@ resource "aws_efs_mount_target" "mounts" {
 
 resource "aws_security_group" "efs" {
   name        = "${var.security_group_name}"
-  description = "Security group for EFS"
+  description = "${var.security_group_description}"
   vpc_id      = "${var.vpc_id}"
 
   tags = "${var.tags}"

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -15,30 +15,26 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_kms_key" "encryption" {
+  count = "${var.enable_encryption ? 1 : 0}"
+
   description             = "${var.kms_key_description}"
   deletion_window_in_days = "${var.kms_key_deletion_window_in_days}"
   enable_key_rotation     = "${var.kms_key_enable_rotation}"
   policy                  = "${local.kms_key_policy_json}"
   tags                    = "${merge(var.kms_additional_tags, var.tags)}"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_kms_alias" "encryption" {
+  count = "${var.enable_encryption ? 1 : 0}"
+
   name          = "${local.kms_key_alias}"
-  target_key_id = "${aws_kms_key.encryption.key_id}"
+  target_key_id = "${local.kms_key_id}"
 }
 
 resource "aws_efs_file_system" "default" {
-  encrypted  = true
-  kms_key_id = "${aws_kms_key.encryption.arn}"
+  encrypted  = "${var.enable_encryption}"
+  kms_key_id = "${local.kms_key_arn}"
   tags       = "${var.tags}"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_efs_mount_target" "mounts" {
@@ -72,6 +68,10 @@ locals {
 
   # timestamp() returns 2018-01-02T23:12:01Z, and colon is not allowed for KMS key alias
   formatted_timestamp = "${replace(timestamp(), ":", "-")}"
+
+  # Empty strings if enable_encryption is false
+  kms_key_id  = "${element(concat(aws_kms_key.encryption.*.key_id, list("")), 0)}"
+  kms_key_arn = "${element(concat(aws_kms_key.encryption.*.arn, list("")), 0)}"
 
   kms_key_alias       = "${coalesce(var.kms_key_alias, format("%s%s", var.kms_key_alias_prefix, local.formatted_timestamp))}"
   kms_key_policy_json = "${coalesce(var.kms_key_policy_json, data.aws_iam_policy_document.default.json)}"

--- a/modules/efs/outputs.tf
+++ b/modules/efs/outputs.tf
@@ -50,10 +50,10 @@ output "kms_key_alias" {
 
 output "kms_key_arn" {
   description = "ARN of KMS key used for EFS encryption"
-  value       = "${aws_kms_key.encryption.arn}"
+  value       = "${local.kms_key_arn}"
 }
 
 output "kms_key_key_id" {
   description = "Key ID of KMS key used for EFS encryption"
-  value       = "${aws_kms_key.encryption.key_id}"
+  value       = "${local.kms_key_id}"
 }

--- a/modules/efs/variables.tf
+++ b/modules/efs/variables.tf
@@ -30,6 +30,11 @@ variable "security_group_description" {
 # EFS related
 #
 
+variable "enable_encryption" {
+  description = "Boolean to specify whether to enable KMS encryption for EFS"
+  default     = true
+}
+
 variable "kms_additional_tags" {
   description = "KMS key additional tags for EFS"
   default     = {}

--- a/modules/efs/variables.tf
+++ b/modules/efs/variables.tf
@@ -21,6 +21,11 @@ variable "security_group_name" {
   default     = ""
 }
 
+variable "security_group_description" {
+  description = "Description of security group for EFS"
+  default     = "Security group for EFS"
+}
+
 #
 # EFS related
 #
@@ -28,6 +33,11 @@ variable "security_group_name" {
 variable "kms_additional_tags" {
   description = "KMS key additional tags for EFS"
   default     = {}
+}
+
+variable "kms_key_description" {
+  description = "Description to use for KMS key"
+  default     = "Encryption key for EFS"
 }
 
 variable "kms_key_alias_prefix" {


### PR DESCRIPTION
Allow both SG and KMS descriptions, and also EFS encryption to be specified.

Apparently changing description value for SG causes it to be destroyed and recreated. :thinking: 