### PR TITLE
Fix path append for run-consul-template

### DIFF
--- a/roles/install-consul-template/files/run-consul-template.sh
+++ b/roles/install-consul-template/files/run-consul-template.sh
@@ -536,7 +536,7 @@ function run {
     wait_for_consul "http://${agent_address}" # XXX: What about TLS in future?
 
     local aws_auth_enabled
-    aws_auth_enabled=$(consul_kv_with_default "$(append_paths ${consul_prefix} aws-auth/enabled) " "no")
+    aws_auth_enabled=$(consul_kv_with_default "$(append_paths ${consul_prefix} aws-auth/enabled)" "no")
     if [[ "${aws_auth_enabled}" != "yes" ]]; then
       log_info "AWS Authentication is not enabled"
     else

--- a/roles/install-consul-template/files/run-consul-template.sh
+++ b/roles/install-consul-template/files/run-consul-template.sh
@@ -79,7 +79,7 @@ function join_by {
 # Based on https://unix.stackexchange.com/a/23213
 function append_paths {
   if [ $# -eq 0 ]; then return 1; fi
-  printf "${1%/}"
+  printf '%s' "${1%/}"
   shift
   if [ $# -gt 0 ]; then printf '/%s' "${@%/}"; fi
 }
@@ -141,7 +141,7 @@ function wait_for_consul {
 
   for (( i=1; i<="$MAX_RETRIES"; i++ )); do
     consul_leader=$(
-      curl -sS "$(append_paths ${consul_agent} v1/status/leader)" 2> /dev/null || echo "failed"
+      curl -sS "$(append_paths "${consul_agent}" "v1/status/leader")" 2> /dev/null || echo "failed"
     )
 
     if [[ "${consul_leader}" = "failed" ]]; then
@@ -190,7 +190,7 @@ function request_vault_token {
   local token
   token=$(
     curl -Ss -XPOST --retry 5 \
-      "$(append_paths ${address} v1/auth ${auth_path} login)" \
+      "$(append_paths "${address}" "v1/auth" "${auth_path}" "login")" \
       -d '{ "role": "'"${token_role}"'", "pkcs7": "'"${ec2_identity}"'" }'
   ) || exit $?
 
@@ -348,11 +348,11 @@ function get_vault_token {
 
   # Get the authentication path
   local auth_path
-  auth_path=$(consul_kv "$(append_paths ${consul_prefix} path)")
+  auth_path=$(consul_kv "$(append_paths "${consul_prefix}" "path")")
 
   # Get the role. If the server_type is invalid, this will fail
   local token_role
-  token_role=$(consul_kv "$(append_paths ${consul_prefix} roles ${server_type})")
+  token_role=$(consul_kv "$(append_paths "${consul_prefix}" "roles" "${server_type}")")
 
   local vault_token
   vault_token=$(request_vault_token "${auth_path}" "${token_role}" "${vault_address}") || exit $?
@@ -536,13 +536,13 @@ function run {
     wait_for_consul "http://${agent_address}" # XXX: What about TLS in future?
 
     local aws_auth_enabled
-    aws_auth_enabled=$(consul_kv_with_default "$(append_paths ${consul_prefix} aws-auth/enabled)" "no")
+    aws_auth_enabled=$(consul_kv_with_default "$(append_paths "${consul_prefix}" "aws-auth/enabled")" "no")
     if [[ "${aws_auth_enabled}" != "yes" ]]; then
       log_info "AWS Authentication is not enabled"
     else
 
       local vault_token
-      vault_token=$(get_vault_token "${vault_address}" "$(append_paths ${consul_prefix} aws-auth)" "${server_type}") || exit $?
+      vault_token=$(get_vault_token "${vault_address}" "$(append_paths "${consul_prefix}" "aws-auth")" "${server_type}") || exit $?
       environment+=("VAULT_TOKEN=\"${vault_token}\"")
 
       generate_vault_config "${vault_address}" "$config_dir" "$user"


### PR DESCRIPTION
There is a output change for Vault provider for [`auth_backend`](https://www.terraform.io/docs/providers/vault/r/auth_backend.html), with version >= 2.0 returning `path` as it is, instead of always appending trailing slash like in previous version. Compare:
- Old: https://github.com/terraform-providers/terraform-provider-vault/blob/v1.7.0/vault/resource_auth_backend.go#L157 (returns trailing slash as read output)
- New: https://github.com/terraform-providers/terraform-provider-vault/blob/v2.0.0/vault/resource_auth_backend.go#L151 (returns without trailing slash as read output)

This causes `auth_path` not to contain the trailing slash in https://github.com/datagovsg/terraform-modules/blob/master/roles/install-consul-template/files/run-consul-template.sh#L185 when using Vault provider >= 2.0, which then causes the initialization of Nomad clients instances to fail.

This enhances the `run-consul-template.sh` to handle both trailing and non-trailing slash values for appending.

`append_paths` works in the following way: https://rextester.com/NVR58053
